### PR TITLE
FIX: 유저관리 -> 유저정보 컴포넌트 이동시 useParams 사용, 유저 정보 획득

### DIFF
--- a/src/routes/UserInfo/index.tsx
+++ b/src/routes/UserInfo/index.tsx
@@ -1,49 +1,50 @@
-import { useLocation } from 'react-router-dom'
-
-import { LinkMemberStateProps } from 'types/user'
+import { useParams } from 'react-router-dom'
 
 import styles from './userInfo.module.scss'
 import HeartRateChart from './Charts/HeartRateChart'
 import StepRateChart from './Charts/StepRateChart'
+import { getUserInfoWithId } from 'services/user'
 
 const UserInfo = () => {
-  const location = useLocation()
+  const { userId } = useParams()
 
-  const userInfo: LinkMemberStateProps = location.state as LinkMemberStateProps
+  const user = getUserInfoWithId(userId)
 
   return (
     <>
-      <section className={styles.container}>
-        <h2>회원 상세 정보</h2>
-        <div className={styles.infoContainer}>
-          <dl>
-            <div className={styles.infoBox}>
-              <dt>로그인 ID</dt>
-              <dd>{userInfo.user_id}</dd>
-            </div>
-            <div className={styles.infoBox}>
-              <dt>회원 번호</dt>
-              <dd>{userInfo.user_seq}</dd>
-            </div>
-            <div className={styles.infoBox}>
-              <dt>가입일</dt>
-              <dd>{userInfo.user_registerDate}</dd>
-            </div>
-            <div className={styles.infoBox}>
-              <dt>닉네임</dt>
-              <dd>{userInfo.user_nickname}</dd>
-            </div>
-            <div className={styles.infoBox}>
-              <dt>성별</dt>
-              <dd>{userInfo.user_gender}</dd>
-            </div>
-            <div className={styles.infoBox}>
-              <dt>생년월일</dt>
-              <dd>{userInfo.user_birth}</dd>
-            </div>
-          </dl>
-        </div>
-      </section>
+      {user && (
+        <section className={styles.container}>
+          <h2>회원 상세 정보</h2>
+          <div className={styles.infoContainer}>
+            <dl>
+              <div className={styles.infoBox}>
+                <dt>로그인 ID</dt>
+                <dd>{user.nickname}</dd>
+              </div>
+              <div className={styles.infoBox}>
+                <dt>회원 번호</dt>
+                <dd>{user.member_seq}</dd>
+              </div>
+              <div className={styles.infoBox}>
+                <dt>가입일</dt>
+                <dd>{user.registered_date}</dd>
+              </div>
+              <div className={styles.infoBox}>
+                <dt>닉네임</dt>
+                <dd>{user.nickname}</dd>
+              </div>
+              <div className={styles.infoBox}>
+                <dt>성별</dt>
+                <dd>{user.gender}</dd>
+              </div>
+              <div className={styles.infoBox}>
+                <dt>생년월일</dt>
+                <dd>{user.birth}</dd>
+              </div>
+            </dl>
+          </div>
+        </section>
+      )}
       <div className={styles.charts}>
         <HeartRateChart />
         <StepRateChart />

--- a/src/routes/UserManage/Result/index.tsx
+++ b/src/routes/UserManage/Result/index.tsx
@@ -24,17 +24,7 @@ const Result = ({ data }: Props) => {
       <td>{data.gender}</td>
       <td>{data.birth}</td>
       <td>
-        <Link
-          to='userInfo'
-          state={{
-            user_seq: data.member_seq,
-            user_nickname: data.nickname,
-            user_id: data.user_id,
-            user_gender: data.gender,
-            user_birth: data.birth,
-            user_registerDate: removeTimeInDate(data.registered_date),
-          }}
-        >
+        <Link to={`userInfo/${data.user_id}`}>
           <button type='button'>관리</button>
         </Link>
       </td>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -22,7 +22,7 @@ const App = () => {
         <Route path='' element={<HomePage />} />
         <Route path='userManage' element={<Outlet />}>
           <Route path='' element={<UserManage />} />
-          <Route path='userInfo' element={<UserInfo />} />
+          <Route path='userInfo/:userId' element={<UserInfo />} />
         </Route>
         <Route path='*' element={<NotFoundPage />} />
       </Route>

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -14,6 +14,11 @@ const getMemberSeq = (id: string) => {
   return findUser?.member_seq
 }
 
+export const getUserInfoWithId = (id: string | undefined) => {
+  const findUser = users.find((value) => value.user_id === id)
+  return findUser
+}
+
 export const getMemberInfo = (props: Props) => {
   if (props.id && !props.number) return filterUserWithIdAndDate(props.id, props.startDate, props.endDate)
   if (props.number && !props.id) return filterUserWithNumberAndDate(props.number, props.startDate, props.endDate)


### PR DESCRIPTION
## 개요

이제 유저 관리에서 Link 태그에 해당 사용자 정보를 state로 보내지 않고,

URL의 파라미터를 이용해 유저 정보를 얻습니다.

## 작업 내용


## 특이 사항

## 스크린샷(or 동영상)

<img width="922" alt="image" src="https://user-images.githubusercontent.com/87627359/171732115-c82d9d31-1834-4e57-ac06-81937cf560b7.png">


## 기타
