### PR TITLE
MOD: 초기화 버튼 기능 수정

### DIFF
--- a/src/routes/UserManage/Search/index.tsx
+++ b/src/routes/UserManage/Search/index.tsx
@@ -1,8 +1,8 @@
 import { ChangeEvent, FormEvent, useEffect, useState } from 'react'
-import { useRecoilState, useResetRecoilState } from 'recoil'
+import { useRecoilState } from 'recoil'
 import dayjs from 'dayjs'
 
-import { userInputDataState } from 'states/userSearch'
+import { isSearchInputResetState, userInputDataState } from 'states/userSearch'
 
 import { Button } from 'routes/_components/Button'
 import SearchDateRange from 'routes/_components/SearchDateRange'
@@ -17,6 +17,8 @@ const today = dayjs(new Date()).format('YYYYMMDD')
 
 const Search = () => {
   const [userInputData, setUserInputData] = useRecoilState(userInputDataState)
+  const [, setIsSearchInputReset] = useRecoilState(isSearchInputResetState)
+
   const [weeks, setWeeks] = useState(['20220101', today])
   const [currentCategory, setCurrentCategory] = useState('로그인 ID')
   const [userInput, setUserInput] = useState('')
@@ -31,6 +33,8 @@ const Search = () => {
     if (userInput === '') {
       setUserInputData({
         ...userInputData,
+        userId: undefined,
+        userNumber: undefined,
         startDate: Number(dayjs(weeks[0]).format('YYYYMMDD')),
         endDate: Number(dayjs(weeks[1]).format('YYYYMMDD')),
       })
@@ -58,7 +62,19 @@ const Search = () => {
     }
   }
 
-  const resetSearchOption = useResetRecoilState(userInputDataState)
+  const resetSearchOption = () => {
+    setIsSearchInputReset(true)
+    setCurrentCategory('로그인 ID')
+    setUserInput('')
+    setWeeks(['20220101', today])
+    setUserInputData({
+      ...userInputData,
+      userId: undefined,
+      userNumber: undefined,
+      startDate: 20220101,
+      endDate: Number(today),
+    })
+  }
 
   useEffect(() => {
     if (weeks.length === 0) {

--- a/src/routes/_components/SearchDateRange/index.tsx
+++ b/src/routes/_components/SearchDateRange/index.tsx
@@ -76,7 +76,7 @@ const SearchDateRange = ({ setWeeks }: IProps) => {
       setDateRange([{ ...dateRange[0], startDate: new Date('2022-01-01'), endDate: new Date() }])
       setIsSearchInputReset(false)
     }
-  }, [dateRange, isSearchInputReset, setIsSearchInputReset, setWeeks, today])
+  }, [dateRange, isSearchInputReset, setIsSearchInputReset, setWeeks])
 
   return (
     <section className={styles.container}>

--- a/src/routes/_components/SearchDateRange/index.tsx
+++ b/src/routes/_components/SearchDateRange/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import { Range } from 'react-date-range'
 import { useRecoilState } from 'recoil'

--- a/src/routes/_components/SearchDateRange/index.tsx
+++ b/src/routes/_components/SearchDateRange/index.tsx
@@ -1,6 +1,9 @@
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react'
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
 import dayjs from 'dayjs'
 import { Range } from 'react-date-range'
+import { useRecoilState } from 'recoil'
+
+import { isSearchInputResetState } from 'states/userSearch'
 
 import { Button } from '../Button'
 import styles from './searchDateRange.module.scss'
@@ -20,6 +23,8 @@ const SearchDateRange = ({ setWeeks }: IProps) => {
       key: 'selection',
     },
   ])
+
+  const [isSearchInputReset, setIsSearchInputReset] = useRecoilState(isSearchInputResetState)
 
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
   const [startDate, setStartDate] = useState('전체')
@@ -61,6 +66,17 @@ const SearchDateRange = ({ setWeeks }: IProps) => {
     setWeeks([])
     setDateRange([{ ...dateRange[0], startDate: today, endDate: today }])
   }
+
+  useEffect(() => {
+    if (isSearchInputReset) {
+      setSelectedPeriod('전체')
+      setStartDate('전체')
+      setEndDate('전체')
+      setWeeks([])
+      setDateRange([{ ...dateRange[0], startDate: new Date('2022-01-01'), endDate: new Date() }])
+      setIsSearchInputReset(false)
+    }
+  }, [dateRange, isSearchInputReset, setIsSearchInputReset, setWeeks, today])
 
   return (
     <section className={styles.container}>

--- a/src/states/userSearch.ts
+++ b/src/states/userSearch.ts
@@ -14,3 +14,8 @@ export const userInputDataState = atom<IUserInputData>({
   key: '#userInputDataState',
   default: { userId: undefined, userNumber: undefined, startDate: 20220101, endDate: today },
 })
+
+export const isSearchInputResetState = atom<boolean>({
+  key: '#isSearchInputResetState',
+  default: false,
+})


### PR DESCRIPTION
## 개요

- 초기화 버튼 정상 작동하도록 코드 수정해두었습니다.

## 작업 내용

- Search 컴포넌트에서 초기화 버튼 클릭 시 input 비우고, dropdown '로그인 ID' 로 초기화
- 초기화 버튼 클릭 시 true로 변경되는 recoil state 생성
- SearchDateRange 컴포넌트에서 해당 recoil State 변경에 따라 달력 날짜 전체로 초기화/ 버튼 '전체'에 focus 오도록 설정하는 useEffect 함수 추가

## 특이 사항

- 없음

## 스크린샷(or 동영상)

![수정](https://user-images.githubusercontent.com/87853486/171825745-a0a534a8-2170-48f1-a079-7cf7da5b59f5.gif)


## 기타
